### PR TITLE
Updated for Python 3.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: python
 python:
-  - "3.11"
+  - "3.13"
   - "pypy"
 install: ":"
 script: ./test-everything.sh

--- a/attoconf/types.py
+++ b/attoconf/types.py
@@ -18,8 +18,7 @@
 
 
 import os
-from pipes import quote as shell_quote
-from shlex import split as shell_split
+from shlex import split as shell_split, quote as shell_quote
 
 from .core import trim_trailing_slashes
 


### PR DESCRIPTION
The module 'pipes' was removed as of Python 3.13, but a one-line change to 'shlex' (which was already in use) was easy.